### PR TITLE
Updated heartbeat diagrams

### DIFF
--- a/docs/architecture/assessment-runtime/heartbeat.md
+++ b/docs/architecture/assessment-runtime/heartbeat.md
@@ -9,8 +9,41 @@
 
 ```mermaid
 sequenceDiagram
-    Assessment Runtime ->> Runtime Orchestrator: Set the expected runtime heartbeat interval, ID
-    Runtime Orchestrator ->> Configuration Database: Store heartbeat interval for runtime, ID in config
-    Configuration Database ->> Runtime Orchestrator: Response
-    Runtime Orchestrator ->> Assessment Runtime: Response
+    Assessment Runtime ->> Runtime Orchestrator: Set heartbeat interval
+    Runtime Orchestrator ->> Configuration Database: Store heartbeat interval
+    Configuration Database ->> Runtime Orchestrator: OK
+    Runtime Orchestrator ->> Assessment Runtime: OK
 ```
+
+## Heartbeat Monitoring
+
+1. The **Runtime Orchestrator** retrieves the list of registered **Assessment Runtimes**, along with their configured heartbeat intervals, from the **Configuration Database**.
+2. Next, the **Runtime Orchestrator** stores all the **Assessment Runtime** IDs in a list, accompanied by the latest heartbeats retrieved from the **Event Bus**.
+3. Following this, the **Assessment Runtime** sends a heartbeat pulse, together with its ID, to the **Event Bus**. This action serves as a "heartbeat" from the **Assessment Runtime**, signaling that it is active and functioning properly.
+4. The **Runtime Orchestrator** then gathers all new pulses, including the heartbeat sent by the **Assessment Runtime**, from the **Event Bus** for further processing.
+5. Afterward, the **Runtime Orchestrator** iterates through all the runtimes in the list, evaluating the difference between the configured intervals and the timestamps of the latest heartbeats.
+6. If the difference between the last time a heartbeat was received and the pre-configured interval is found to be greater, the **Runtime Orchestrator** updates the **Configuration Database**, marking the specific runtime as not alive.
+
+```mermaid
+sequenceDiagram
+    participant RO as Runtime Orchestrator
+    participant CD as Configuration Database
+    participant EB as Event Bus
+    participant AR as Assessment Runtime
+
+    RO->>CD: Get Config
+    CD-->>RO: Return list and intervals
+    RO->>RO: Store Assessment Runtime IDs and latest heartbeats
+    AR->>EB: Send heartbeat pulse with ID
+    loop Heartbeat Check
+        RO->>EB: Retrieve all new pulses including heartbeat
+        EB-->>RO: Return new pulses
+        RO->>RO: Iterate through runtimes, evaluate differences
+        Note over RO: If difference is greater than configured interval...
+        RO->>CD: Update Configuration Database (runtime not alive)
+    end
+```
+
+:::note
+We also need some kind of notification mechanism to let the administrators know that the runtime is dead.
+:::


### PR DESCRIPTION
I modified the heartbeat monitoring process a bit. Instead of writing pulse events to the database, I changed it so that the Orchestrator holds a list of registered runtimes and loops through the list to check the heartbeats. Please see the description and the diagram accompanying it.