### PR TITLE
fix: typo

### DIFF
--- a/docs/architecture/core-diagrams.md
+++ b/docs/architecture/core-diagrams.md
@@ -21,8 +21,8 @@ sequenceDiagram
 
 :::caution
 
-There is an issue here whjich is the cost to understand the scenario to properly create the metrics. This could be solved by an update on the Configuration diagrams to also include a responsibility on the configuration to generate a Metrics Plan, and a separate endpoint to add metrics according to the metrics plan.
-This needs to be done to a specific service, otherwise it is going to be computationally heavy to update metrics on the configuration (?)
+There is an issue here which is the cost to understand the scenario to properly create the metrics. This could be solved by an update on the Configuration diagrams to also include a responsibility on the configuration to generate a Metrics Plan, and a separate endpoint to add metrics according to the metrics plan.
+This needs to be done to a specific service, otherwise, it is going to be computationally heavy to update metrics on the configuration (?)
 
 :::
 


### PR DESCRIPTION
or this could better read like so (?)

```
There is an issue related to the complexity of understanding the scenario to accurately create metrics. This problem might be resolved by updating the Configuration diagrams. The update should include defining responsibilities for generating a Metrics Plan and creating a separate endpoint to add metrics according to this plan. Implementing these changes for a specific service is crucial; otherwise, it will become computationally burdensome to update metrics within the overall configuration.
```