### PR TITLE
fix: gh page deploy failure + copyright typo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile --non-interactive

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Compliance Framwwork. Built with Docusaurus.`,
+        copyright: `Copyright © ${new Date().getFullYear()} Compliance Framework. Built with Docusaurus.`,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version in deployment workflow from 16.x to 20.x

* **Documentation**
  * Fixed spelling error in site footer copyright text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->